### PR TITLE
Сортировка дерева (рутов)

### DIFF
--- a/Components/NestedAdmin.php
+++ b/Components/NestedAdmin.php
@@ -142,7 +142,7 @@ abstract class NestedAdmin extends ModelAdmin
         if (!isset($data['pk'])) {
             throw new Exception("Failed to receive primary key");
         }
-//        d($data);
+
         /** @var \Mindy\Orm\TreeModel $modelClass */
         $modelClass = $this->getModel();
 


### PR DESCRIPTION
Поясняю, что было не так. Для примера возьмем дерево следующего содержания:

```
- Носки (root=0)
   - Черные (root=0)
   - Белые (root=0)
- Мебель (root=1)
   - Деревянная (root=1)
   - Металлическая (root=1)
```
И поменяем в админке руты местами.

По старой логике происходило так:

Обновлялись руты:

```
- Носки (root=1)
   - Черные (root=0)
   - Белые (root=0)
- Мебель (root=0)
   - Деревянная (root=1)
   - Металлическая (root=1)
```

Затем, в первую итерацию обновлялись дочки первого элемента (выборка по root=0):

```
- Носки (root=1)
   - Черные (root=1)
   - Белые (root=1)
- Мебель (root=0)
   - Деревянная (root=1)
   - Металлическая (root=1)
```

Затем, во вторую итерацию происходила выборка дочек второго элемента с root=1, вот тут и возникала ошибка, так как в выборку попадают все дочки (и первого рута и второго), и получалась каша вида:

```
- Носки (root=1)
   - Черные (root=0)
   - Белые (root=0)
- Мебель (root=0)
   - Деревянная (root=0)
   - Металлическая (root=0)
```